### PR TITLE
refactor: extract keyboard mappings

### DIFF
--- a/src/editor_keyboard_event.ts
+++ b/src/editor_keyboard_event.ts
@@ -1,0 +1,144 @@
+/* Kullna Editor - A small but feature-rich code editor for the web
+   Copyright (C) 2022-2023 The Kullna Programming Language Project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>. */
+
+/**
+ * The `EditorKeyboardEvent` class wraps a `KeyboardEvent` and provides
+ * additional functionality for working with keyboard events.
+ * @remarks This class is used internally by the editor and is not intended
+ * to be used directly.
+ * @internal
+ */
+export class EditorKeyboardEvent {
+  constructor(public readonly event: KeyboardEvent) {}
+
+  /**
+   * Prevents the default action of the event.
+   */
+  preventDefault() {
+    this.event.preventDefault();
+  }
+
+  /**
+   * Stops the propagation of the event.
+   */
+  stopPropagation() {
+    this.event.stopPropagation();
+  }
+
+  /**
+   * True if the default action of the event has been prevented.
+   */
+  get defaultPrevented(): boolean {
+    return this.event.defaultPrevented;
+  }
+
+  /**
+   * Obtains the key code from a keyboard event.
+   */
+  get keyCode(): string {
+    const key = this.event.key ?? this.event.keyCode ?? this.event.which;
+    if (!key) return '';
+    return (typeof key === 'string' ? key : String.fromCharCode(key)).toUpperCase();
+  }
+
+  /**
+   * True if the given event contains a 'shift' key.
+   */
+  get isShift(): boolean {
+    return this.event.shiftKey;
+  }
+
+  /**
+   * True if the given event contains a 'ctrl' key.
+   */
+  get isCtrl(): boolean {
+    return this.event.metaKey || this.event.ctrlKey;
+  }
+
+  /**
+   * True if the given event represents a standard 'undo' keyboard sequence.
+   */
+  get isUndo(): boolean {
+    return this.isCtrl && !this.isShift && this.keyCode === 'Z';
+  }
+
+  /**
+   * True if the given event represents a standard 'redo' keyboard sequence.
+   */
+  get isRedo(): boolean {
+    return this.isCtrl && this.isShift && this.keyCode === 'Z';
+  }
+
+  /**
+   * True if the given event represents a standard 'copy' keyboard sequence.
+   */
+  get isCopy(): boolean {
+    return this.isCtrl && this.keyCode === 'C';
+  }
+
+  /**
+   * True if the given event represents a standard 'paste' keyboard sequence.
+   */
+  get isPaste(): boolean {
+    return this.isCtrl && this.keyCode === 'V';
+  }
+
+  /**
+   * True if the event represents a keyboard sequence that is likely
+   * going to mutate the contents of the editor directly in some way and should
+   * be recorded in the undo/redo history. If this method ever returns false
+   * for a keyboard sequence that does mutate the editor, the undo/redo history
+   * will be corrupted.
+   */
+  get isMutatingInput(): boolean {
+    return (
+      !this.isUndo &&
+      !this.isRedo &&
+      !this.isArrow &&
+      this.event.key !== 'Meta' &&
+      this.event.key !== 'Control' &&
+      this.event.key !== 'Alt'
+    );
+  }
+
+  /**
+   * True if the event is fired within a composition session.
+   */
+  get isComposing(): boolean {
+    return this.event.isComposing;
+  }
+
+  /**
+   * True if the event represents an 'enter' key press.
+   */
+  get isEnter(): boolean {
+    return this.keyCode === 'ENTER';
+  }
+
+  /**
+   * True if the event represents a 'tab' key press.
+   */
+  get isTab(): boolean {
+    return this.keyCode === 'TAB';
+  }
+
+  /**
+   * True if the event represents one of the 'arrow' key press.
+   */
+  get isArrow(): boolean {
+    return (this.keyCode ?? '').startsWith('ARROW');
+  }
+}

--- a/src/editor_options.ts
+++ b/src/editor_options.ts
@@ -1,0 +1,111 @@
+/* Kullna Editor - A small but feature-rich code editor for the web
+   Copyright (C) 2022-2023 The Kullna Programming Language Project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>. */
+
+// skipcq: JS-C1003: Wildcard Imports
+import * as Gutter from './gutter';
+
+/**
+ * The `EditorOptions` interface specifies the options that can be
+ * passed to the `Editor` constructor.
+ */
+export interface EditorOptions {
+  /**
+   * The `tab` option specifies the string that is inserted when the
+   * user presses the tab key.
+   */
+  tab: string;
+  /**
+   * The `indentOn` option specifies a regular expression that is used
+   * to determine whether the editor should indent the new line further
+   * when the user presses the enter key.
+   */
+  indentOn: RegExp;
+  /**
+   * The `moveToNewLine` option specifies a regular expression that is
+   * used to determine whether the editor should move the cursor to the
+   * beginning of the next line when the user presses the enter key.
+   */
+  moveToNewLine: RegExp;
+  /**
+   * The `spellcheck` option specifies whether the editor should
+   * spellcheck the text.
+   */
+  spellcheck: boolean;
+  /**
+   * The `catchTab` option specifies whether the editor should catch
+   * the tab key and prevent it from moving focus to the next element
+   * as well as allowing the user to indent the current line or insert
+   * a tab character.
+   * This setting is currently enabled by default.
+   */
+  catchTab: boolean;
+  /**
+   * Enabling `multilineIndentation` allows users to select blocks of
+   * text and indent (or dedent) them with the tab (or shift-tab) key.
+   * This setting is currently disabled by default.
+   *
+   * Note that this feature does not currently work with Firefox, and
+   * will be disabled automatically if the browser does not support it.
+   */
+  multilineIndentation: boolean;
+  /**
+   * If `preserveIdent` is true, the editor will preserve the
+   * indentation of the current line on the next line when pressing enter.
+   */
+  preserveIdent: boolean;
+  /**
+   * If `addClosing` is true, the editor will automatically add closing
+   * brackets, quotes, etc. when typing.
+   */
+  addClosing: boolean;
+  /**
+   * If `history` is true, the editor will keep track of the user's
+   * history and allow them to undo/redo changes.
+   */
+  history: boolean;
+  /**
+   * If `window` is defined, the editor will use the given window
+   * instead of the global `window` object.
+   */
+  window: typeof window;
+  /**
+   * The `contentClass` option specifies the class name that is added
+   * to the editor's content element.
+   */
+  contentClass: string;
+  /**
+   * The `gutter` option specifies options for the gutter and line
+   * numbers.
+   */
+  gutter: Partial<Gutter.GutterOptions>;
+  /**
+   * The `language` option specifies the language that is used for
+   * syntax highlighting. It does this by adding a class named "language-[language]"
+   * to the editor's content element.
+   */
+  language: string;
+  /**
+   * The `highlight` option specifies a function that is called when
+   * the editor is updated. The function is passed the editor element
+   * and can be used to highlight the code.
+   */
+  highlight?: (e: HTMLElement) => void;
+  /**
+   * The `dir` option specifies the direction of prevailing script
+   * used in the editor.
+   */
+  dir: 'ltr' | 'rtl';
+}


### PR DESCRIPTION
Extracts the logic that deals with mapping keyboard events into their semantic meanings into a separate class as part of moving code out of the monolithic function.

## Pre-Review Checklist:

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

- [x] I `Steven E Wright` agree to the **Developer Certificate of Origin**
- [x] I have reviewed the License Agreement at [LICENSE.md](https://github.com/kullna/editor/blob/main/LICENSE.md)
