### PR TITLE
fix: github ci broken on push

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,10 +1,10 @@
 # This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Kullna Editor CI
+name: Kullna PR Actions
 
 on:
-  push:
+  pull_request:
     branches: ['main']
     paths-ignore: ['**.md']
 
@@ -26,3 +26,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: './package-lock.json'
       - run: ./ci
+      - uses: andresz1/size-limit-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "size-limit": [
     {
       "path": "./dist/kullna-editor.min.js",
-      "limit": "6.5 KB"
+      "limit": "8 KB"
     }
   ],
   "exports": {


### PR DESCRIPTION
Fixes an issue where the CI script that runs when main is updated included the app size checker which is only for PR runs.

## Developer Certificate of Origin

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

- [x] I `<Signature>` agree to the **Developer Certificate of Origin**
- [x] I have reviewed the License Agreement at
      [LICENSE.md](https://github.com/kullna/editor/blob/main/LICENSE.md)
