### PR TITLE
fix: add permissions to workflows

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,6 +11,8 @@ permissions:
   contents: write
   pull-requests: write
   statuses: write
+  pages: write
+  id-token: write
 
 jobs:
   CLAAssistant:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,18 @@
+##.github/workflows/release.yml
+name: Website Deployment
+on: workflow_dispatch
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - run: ./ci
+      - run: ./website
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: './docs/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,6 +1,10 @@
 ##.github/workflows/release.yml
 name: Website Deployment
 on: workflow_dispatch
+permissions:
+    contents: read
+    pages: write
+    id-token: write
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Just adds permissions to workflows for pages deployment

## Developer Certificate of Origin

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

- [ ] I `<Signature>` agree to the **Developer Certificate of Origin**
- [ ] I have reviewed the License Agreement at
      [LICENSE.md](https://github.com/kullna/editor/blob/main/LICENSE.md)
