### PR TITLE
fix: remove z-index usage

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -4,43 +4,8 @@
 
 ### _css_
 
-```html
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/styles/base16/solarized-dark.min.css"
-/>
-```
-
-### _js_
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/@kullna/editor/dist/kullna-editor.min.js"></script>
-<script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/highlight.min.js"></script>
-```
-
-### _html_
-
-```html
-<div id="editor"></div>
-```
-
-### _init_
-
-```js
-const editor = KullnaEditor.createEditor('#editor', {
-  language: 'javascript',
-  highlightElement: hljs.highlightElement
-});
-editor.spellcheck = false;
-editor.code = 'print("Hello, world!")';
-```
-
-💡 **Tip:** Check out the other options in the [Documentation](/interfaces/Options.html).
-
-## Styling
-
 We recommend the use of the [Source Code Pro](https://fonts.google.com/specimen/Source+Code+Pro)
-font for the editor. You can include it in your page like this:
+font for the editor.
 
 ```html
 <link
@@ -49,8 +14,8 @@ font for the editor. You can include it in your page like this:
 />
 ```
 
-We are also partial to Highlight.js's Solarized Dark theme for syntax highlighting. You can include
-it in your page like this:
+And Highlight.JS's Solarized Dark
+[Theme](https://github.com/highlightjs/highlight.js/tree/main/src/styles):
 
 ```html
 <link
@@ -59,76 +24,104 @@ it in your page like this:
 />
 ```
 
-Finally, we like the following styles for a small embedded editor. This example gives you a good
-starting point for customizing the editor to your needs:
+And we'll style our editor DIV to look nice, and use an appropriate font for a code editor:
 
 ```html
 <style>
-  .editor {
-    border-radius: 6px;
+  #editor {
+    position: relative;
+    min-height: 480px;
+    min-width: 640px;
+
+    background-color: #073642;
+
     font-family: 'Source Code Pro', monospace;
-    font-size: 14px;
-    font-weight: 400;
-    min-height: 240px;
+    font-size: 12px;
     line-height: 20px;
+
+    border-radius: 10px;
   }
 
-  .editor > div {
-    padding: 10px;
-  }
-
-  .gutter {
+  #editor .gutter {
     background-color: #002b36;
-    color: #839496;
+    border-color: #93a1a1;
+    color: #93a1a1;
   }
 </style>
 ```
 
-## Use with Highlight.js
-
-### _css_
-
-```html
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/styles/base16/solarized-dark.min.css"
-/>
-```
-
 ### _js_
 
+We can get @kullna/editor and Highlight.JS from JSDelivr:
+
 ```html
+<script src="https://cdn.jsdelivr.net/npm/@kullna/editor/dist/kullna-editor.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.8.0/build/highlight.min.js"></script>
 ```
 
-### _init_
+### _html_
 
-```js
-const editor = KullnaEditor.createEditor(editorElement, {
-  language: 'javascript',
-  highlightElement: hljs.highlightElement
-});
-```
-
-## Use with Prism.js
-
-### _css_
+We need the element to hold the editor in the DOM:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism.min.css" />
-```
-
-### _js_
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
+<div id="editor"></div>
 ```
 
 ### _init_
 
+Initialize the editor, and set your options:
+
 ```js
-const editor = KullnaEditor.createEditor(editorElement, {
+const editor = KullnaEditor.createEditor('#editor', {
   language: 'javascript',
-  highlightElement: Prism.highlightElement
+  // This tells the editor to use Highlight.JS for syntax highlighting:
+  highlightElement: hljs.highlightElement,
+  // This tells the editor to show a gutter with line numbers and a border:
+  gutter: {
+    border: true,
+    class: 'gutter'
+  }
+});
+// Warning! Disabling spellcheck will disable spellcheck for the entire page.
+editor.spellcheck = false;
+```
+
+Set the code in the editor:
+
+```js
+editor.code = 'print("Hello, world!")';
+```
+
+Get notified when the code changes:
+
+```js
+editor.onUpdate(code => {
+  console.log('Code updated:', code);
 });
 ```
+
+Print code on demand:
+
+```js
+console.log(editor.code);
+```
+
+Create a highlight:
+
+```js
+const highlight = editor.createHighlight();
+highlight.cssClass = 'highlight';
+highlight.lineNumber = 1;
+highlight.visible = true;
+```
+
+💡 **Tip:** Check out the other options in the [Documentation](/interfaces/Options.html). Also,
+check out [Processors](/modules/Processors.html) for handling keyboard events.
+
+---
+
+The Kullna Editor source, artifacts, and website content are **Copyright (c) 2023
+[The Kullna Programming Language Project](https://www.kullna.org/).**
+
+They are free to use and open-source under the terms of the
+[GNU Lesser General Public License](https://www.gnu.org/licenses/lgpl-3.0).

--- a/demo.html
+++ b/demo.html
@@ -63,6 +63,7 @@
       }
 
       .editor {
+        position: relative;
         background-color: var(--sd-base02);
         border-radius: 10px;
         box-shadow:

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,12 +71,21 @@ const DEFAULT_TAB_CHARACTERS = '  ';
  * Here is a typical example of how to create an editor:
  *
  * ```js
- * const editor = KullnaEditor.createEditor('#editor', {
+ * import {createEditor} from '@kullna/editor';
+ *
+ * const editor = createEditor('#editor', {
  *   language: 'javascript',
- *   highlightElement: hljs.highlightElement
+ *   // This tells the editor to use Highlight.JS for syntax highlighting:
+ *   highlightElement: hljs.highlightElement,
+ *   // This tells the editor to show a gutter with line numbers and a border:
+ *   gutter: {
+ *     border: true,
+ *     class: 'gutter'
+ *   }
  * });
+ * // Warning! Disabling spellcheck will disable spellcheck for the entire page.
  * editor.spellcheck = false;
- * editor.code = 'console.log("Hello, world!");';
+ * editor.wrapsText = true;
  * ```
  *
  * For a list of features and options you can change after creating the editor, see the
@@ -158,6 +167,9 @@ export function createEditor(
   };
   if (options.gutter) {
     editorOptions.gutter = options.gutter;
+  }
+  if (options.language) {
+    editorOptions.language = options.language;
   }
 
   return new Editor(parent, editorOptions);

--- a/src/internals/editor.ts
+++ b/src/internals/editor.ts
@@ -87,11 +87,12 @@ export class Editor
     };
     this.options = options;
 
-    parent.style.position = 'relative';
+    this.undoRedoManager = new UndoRedoManager(this);
+
     parent.style.overflow = 'hidden';
     parent.dir = options.dir;
 
-    this.highlightView = new HighlightView(parent, 99);
+    this.view = new TextEditorView(options.window, parent, this);
 
     if (options.gutter) {
       // Default gutter options if not specified:
@@ -102,12 +103,20 @@ export class Editor
       // Construct the gutter element
       const gutter = new Gutter(options.gutter);
       this.gutter = gutter;
-      parent.appendChild(gutter.element);
+      parent.insertBefore(gutter.element, this.view.contentEditableSurface);
       gutter.dir = options.dir;
     }
 
-    this.undoRedoManager = new UndoRedoManager(this);
-    this.view = new TextEditorView(options.window, parent, this);
+    const highlightViewContainer = this.options.window.document.createElement('div');
+    highlightViewContainer.style.position = 'absolute';
+    highlightViewContainer.style.top = '0';
+    highlightViewContainer.style.left = '0';
+    highlightViewContainer.style.right = '0';
+    highlightViewContainer.style.bottom = '0';
+    highlightViewContainer.style.overflow = 'hidden';
+    parent.insertBefore(highlightViewContainer, this.view.contentEditableSurface);
+    this.highlightView = new HighlightView(highlightViewContainer);
+
     this.view.gutterWidth = this.gutter ? this.gutter.width : '0px';
     this.view.spellchecking = options.spellcheck;
     this.view.dir = options.dir;

--- a/src/internals/gutter/docs_index.ts
+++ b/src/internals/gutter/docs_index.ts
@@ -21,17 +21,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. */
  * the DOM elements within the gutter. This approach anticipates future optimization
  * where we aim to manage gutter elements more efficiently by reusing them, rather than
  *  creating new ones every time the line count in the editor changes. This strategy
- * requires the editor to have complete control over these gutter elements. Presently,
- * the gutter also determines the line's location within the editor, crucial for line
- * numbers and highlighting - however, this source of truth will shift to the internals
- * of the selection bridge in the future, as it knows the line's location within the
- * editor already, and defininitively.
- *
- * Currently line highlighting is handled by the gutter, but this will change in the future
- * when we have a better, more flexible, and more performant way of tracking line heights
- * and positions.
+ * requires the editor to have complete control over these gutter elements.
  */
-
 export {GutterLineElement} from './line';
 export {GutterCustomizer} from './customizer';
 export {Gutter} from './gutter';

--- a/src/internals/gutter/gutter.ts
+++ b/src/internals/gutter/gutter.ts
@@ -148,7 +148,6 @@ export class Gutter {
     };
     this.element = document.createElement('div');
     this.element.style.position = 'absolute';
-    this.element.style.zIndex = '50';
     this.element.style.top = '0px';
     this.element.style.bottom = '0px';
     this.element.style.overflow = 'hidden';

--- a/src/internals/gutter/index.ts
+++ b/src/internals/gutter/index.ts
@@ -30,9 +30,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. */
  * and border colors:
  *
  * ```css
- * background-color: #f0f0f0;
- * border-color: #d0d0d0;
- * color: #606060;
+ * #editor .gutter {
+ *   background-color: #002b36;
+ *   border-color: #93a1a1;
+ *   color: #93a1a1;
+ * }
+ * ```
+ *
+ * To customize the width of the gutter, use the Javascript API:
+ *
+ * ```js
+ * const editor = createEditor('#editor', {
+ *   gutter: {
+ *     width: '100px'
+ *   }
+ * });
  * ```
  *
  * ### JavaScript Customization
@@ -41,17 +53,18 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. */
  *
  * For additional details, refer to {@link GutterCustomizer}.
  *
- * ## Development Notes
- *
- * 💡 **Note:** **Management by `@kullna/editor`**: The editor handles creating and maintaining
- *  the DOM elements within the gutter. This approach anticipates future optimization
- * where we aim to manage gutter elements more efficiently by reusing them, rather than
- *  creating new ones every time the line count in the editor changes. This strategy
- * requires the editor to have complete control over these gutter elements. Presently,
- * the gutter also determines the line's location within the editor, crucial for line
- * numbers and highlighting - however, this source of truth will shift to the internals
- * of the selection bridge in the future, as it knows the line's location within the
- * editor already, and defininitively.
+ * ```
+ *       .breakpoint {
+ *         background-color: var(--sd-red);
+ *         position: absolute;
+ *         border-radius: 50%;
+ *         width: 0.8em;
+ *         height: 0.8em;
+ *         display: inline-flex;
+ *         margin-left: -38px;
+ *         margin-top: 5px;
+ *       }
+ * ```
  */
 
 export {GutterLineElement} from './line';

--- a/src/internals/gutter/index.ts
+++ b/src/internals/gutter/index.ts
@@ -37,6 +37,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. */
  * }
  * ```
  *
+ * Set the class the gutter uses by providing a `class` option to {@link Options.gutter}:
+ *
+ * ```js
+ * const editor = createEditor('#editor', {
+ *   gutter: {
+ *     class: 'gutter'
+ *   }
+ * });
+ * ```
+ *
  * To customize the width of the gutter, use the Javascript API:
  *
  * ```js
@@ -51,20 +61,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. */
  *
  * Beyond CSS, you can modify the gutter using JavaScript. This is achieved by providing a `GutterCustomizer` to the `renderGutterLine` option within {@link Options.gutter}. This function lets you modify the `GutterLineElement` in the DOM, facilitating additions like breakpoints and other gutter features.
  *
- * For additional details, refer to {@link GutterCustomizer}.
- *
- * ```
- *       .breakpoint {
- *         background-color: var(--sd-red);
- *         position: absolute;
- *         border-radius: 50%;
- *         width: 0.8em;
- *         height: 0.8em;
- *         display: inline-flex;
- *         margin-left: -38px;
- *         margin-top: 5px;
- *       }
- * ```
+ * For additional details, including examples, refer to {@link GutterCustomizer}.
  */
 
 export {GutterLineElement} from './line';

--- a/src/internals/highlights/highlight.ts
+++ b/src/internals/highlights/highlight.ts
@@ -30,6 +30,24 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. */
  *
  * Set the visibility of the highlight with `highlight.visible` (see: {@link Highlight.visible}).
  * This will show or hide the highlight.
+ *
+ * ## Example
+ *
+ * ```js
+ * const highlight = editor.createHighlight();
+ * highlight.cssClass = 'highlight';
+ * highlight.lineNumber = 1;
+ * highlight.visible = true;
+ * ```
+ *
+ * ## Example CSS:
+ *
+ * ```css
+ * .highlight {
+ *   /* semi-transparent yellow highlight * /
+ *   background-color: #b5890066;
+ * }
+ * ```
  */
 export interface Highlight {
   /** The line number to highlight. */

--- a/src/internals/highlights/highlight_view.ts
+++ b/src/internals/highlights/highlight_view.ts
@@ -31,12 +31,8 @@ export class HighlightView {
    * Creates a new highlight manager.
    *
    * @param parent The parent element to append the highlight container to.
-   * @param zIndex The z-index of the highlight container.
    */
-  constructor(
-    parent: HTMLElement,
-    readonly zIndex: number
-  ) {
+  constructor(parent: HTMLElement) {
     this.highlightContainerView = parent;
   }
 
@@ -83,7 +79,7 @@ class HighlightLineView implements Highlight {
   private readonly highlightElement: HTMLElement;
 
   constructor(private readonly manager: HighlightView) {
-    this.highlightElement = createHighlightElement(manager.zIndex);
+    this.highlightElement = createHighlightElement();
     this.manager.highlightContainerView.appendChild(this.highlightElement);
   }
 
@@ -142,10 +138,9 @@ class HighlightLineView implements Highlight {
 /**
  * Creates a new DOM element that represents a horizontal highlight.
  *
- * @param zIndex The z-index of the highlight.
  * @returns A DOM element that represents a horizontal highlight.
  */
-function createHighlightElement(zIndex: number): HTMLElement {
+function createHighlightElement(): HTMLElement {
   const highlight = document.createElement('div');
   highlight.className = 'highlight';
   highlight.style.position = 'absolute';
@@ -153,7 +148,6 @@ function createHighlightElement(zIndex: number): HTMLElement {
   highlight.style.right = '0px';
   highlight.style.margin = '0px';
   highlight.style.padding = '0px';
-  highlight.style.zIndex = `${zIndex}`;
   highlight.innerHTML = '&nbsp;';
   return highlight;
 }

--- a/src/internals/highlights/index.ts
+++ b/src/internals/highlights/index.ts
@@ -28,6 +28,28 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>. */
  * - Lines with bookmarks
  * - Lines with TODOs
  *
+ * ## Creating a highlight
+ *
+ * Create a reactive highlight object with {@link KullnaEditor.createHighlight}:
+ *
+ * ```js
+ * const highlight = editor.createHighlight();
+ * highlight.cssClass = 'highlight';
+ * highlight.lineNumber = 1;
+ * highlight.visible = true;
+ * ```
+ *
+ * Changing the properties of the highlight will automatically update the editor.
+ *
+ * ## Deleting a highlight
+ *
+ * When you no longer want a highlight, and changing its visibility is not enough,
+ * you can delete it entirely:
+ *
+ * ```js
+ * highlight.delete();
+ * ```
+ *
  * See the {@link Highlight} interface for more information.
  */
 export {Highlight} from './highlight';

--- a/src/kullna_editor.ts
+++ b/src/kullna_editor.ts
@@ -30,10 +30,16 @@ import {TextDocument} from './internals/text_editor';
  *
  * const editor = createEditor('#editor', {
  *   language: 'javascript',
- *   highlightElement: hljs.highlightElement
+ *   // This tells the editor to use Highlight.JS for syntax highlighting:
+ *   highlightElement: hljs.highlightElement,
+ *   // This tells the editor to show a gutter with line numbers and a border:
+ *   gutter: {
+ *     border: true,
+ *     class: 'gutter'
+ *   }
  * });
+ * // Warning! Disabling spellcheck will disable spellcheck for the entire page.
  * editor.spellcheck = false;
- * editor.code = 'print("Hello, world!")';
  * ```
  *
  * See the Package Documentation {@link @kullna/editor} for more information.

--- a/src/options.ts
+++ b/src/options.ts
@@ -31,19 +31,18 @@ export {type InputProcessor} from './internals/pipeline';
  * but they are included here for your reference:
  *
  * ```js
- * const element = document.getElementById('editor');
- * const editor = KullnaEditor.createEditor(element, {
+ * const editor = KullnaEditor.createEditor('#editor', {
  *     window,
+ *     dir: 'ltr',
  *     tab: '  ',
  *     language: 'javascript',
  *     highlightElement: hljs.highlightElement,
- *     dir: 'ltr',
  *     maxUndoHistory: 300,
  *     gutter: {
- *         width: '55px',
- *         dir: 'ltr',
  *         class: 'gutter',
- *         customizer: (line, element) => {
+ *         width: '55px',
+ *         border: false,
+ *         renderGutterLine: (line, element) => {
  *             // Customize the line numbers in the gutter
  *         },
  *     },
@@ -62,10 +61,12 @@ export {type InputProcessor} from './internals/pipeline';
  *         replacement ? : DefaultProcessors.enter({...
  *         })
  *     },
- *     keydownProcessor: {
- *         replacement: DefaultProcessors.keydown({...
+ *     bracketProcessor: {
+ *         replacement: DefaultProcessors.bracket({...
  *         })
- *     }
+ *     },
+ *     keydownPipeline: [ ... ],
+ *     keyupPipeline: [ ... ]
  * });
  * ```
  */
@@ -94,6 +95,9 @@ export interface Options {
    * from the processor configurations to here.
    */
   tab: string;
+
+  /** The language to use for syntax highlighting. */
+  language?: string;
 
   /**
    * The syntax highlighting function. This function is called whenever the editor's text changes

--- a/test.html
+++ b/test.html
@@ -63,6 +63,7 @@
       }
 
       .editor {
+        position: relative;
         background-color: var(--sd-base02);
         border-radius: 10px;
         box-shadow:


### PR DESCRIPTION
Previously we used z-indexing to put our layers in the correct order, but here we improve this situation a little bit by just putting the layers in the correct order in the DOM.

Also, improves some documentation.

**Github Issue List: ** closes #31 

## Developer Certificate of Origin

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

- [ ] I `Steven E Wright` agree to the **Developer Certificate of Origin**
- [ ] I have reviewed the License Agreement at
      [LICENSE.md](https://github.com/kullna/editor/blob/main/LICENSE.md)
