### PR TITLE
feat: expose the scroll height

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -194,8 +194,14 @@
         parent.appendChild(element);
 
         const editor = KullnaEditor.createEditor(element, options);
+
+        const highlight = editor.createHighlight();
+        highlight.lineNumber = 0;
+        highlight.cssClass = 'code-gutter-highlight';
+        highlight.visible = true;
+
         editor.onSelectionFocusChanged(document => {
-          editor.highlightedLine = document.currentLineNumber;
+          highlight.lineNumber = document.currentLineNumber;
         });
         editor.code = defaultValue;
 
@@ -210,7 +216,7 @@
         const standard = demoWithOptions(
           '#demos',
           'standard',
-          'Standard Configuration',
+          'Standard Configuration (Auto-Sizing)',
           {
             language: 'html',
             highlightElement: e => {
@@ -252,6 +258,10 @@
         standardHighlight.lineNumber = 4;
         standardHighlight.visible = true;
         standardHighlight.cssClass = 'breakpoint-highlight';
+        standard.onUpdate(code => {
+          const element = document.getElementById('editor-standard');
+          element.style.height = standard.naturalHeight;
+        });
 
         demoWithOptions(
           '#demos',

--- a/src/internals/editor.ts
+++ b/src/internals/editor.ts
@@ -186,6 +186,11 @@ export class Editor
   }
 
   /** @inheritDoc */
+  get naturalHeight(): number {
+    return this.view.naturalHeight;
+  }
+
+  /** @inheritDoc */
   scrollToLine(line: number): void {
     this.view.scrollToLine(line);
   }
@@ -360,6 +365,9 @@ export class Editor
     if (!programmatic) {
       if (this.options.onUpdate) {
         this.options.onUpdate(this.code);
+      }
+      if (this.options.onSelectionFocusChanged) {
+        this.options.onSelectionFocusChanged(this.view.document);
       }
     }
   }

--- a/src/internals/editor.ts
+++ b/src/internals/editor.ts
@@ -186,7 +186,7 @@ export class Editor
   }
 
   /** @inheritDoc */
-  get naturalHeight(): number {
+  get naturalHeight(): string {
     return this.view.naturalHeight;
   }
 

--- a/src/internals/text_editor/dom/dom_bridge.ts
+++ b/src/internals/text_editor/dom/dom_bridge.ts
@@ -68,8 +68,8 @@ export class DomBridge {
     if (document.perceptuallyEquals(oldDocument)) {
       this._onDocumentSelectionChangedCallbacks.forEach(callback => callback(document));
     } else {
-      this._onDocumentContentAndSelectionChangedCallbacks.forEach(callback => callback(document));
       this.recalculateLineMetrics();
+      this._onDocumentContentAndSelectionChangedCallbacks.forEach(callback => callback(document));
     }
   }
 

--- a/src/internals/text_editor/text_editor_view.ts
+++ b/src/internals/text_editor/text_editor_view.ts
@@ -264,6 +264,11 @@ export class TextEditorView {
     this._bridge.pushToDOM(document);
   }
 
+  /** @inheritDoc */
+  get naturalHeight(): number {
+    return this.contentEditableSurface.scrollHeight;
+  }
+
   /**
    * Template pattern for adding an event listener to the DOM and our list.
    *

--- a/src/internals/text_editor/text_editor_view.ts
+++ b/src/internals/text_editor/text_editor_view.ts
@@ -265,8 +265,14 @@ export class TextEditorView {
   }
 
   /** @inheritDoc */
-  get naturalHeight(): number {
-    return this.contentEditableSurface.scrollHeight;
+  get naturalHeight(): string {
+    const lastLine = this.lineMetrics[this.lineMetrics.length - 1];
+    const bottomContent = lastLine.top + lastLine.height;
+    let bottomPadding = getComputedStyle(this.contentEditableSurface).paddingBottom;
+    if (!bottomPadding || bottomPadding.length === 0) {
+      bottomPadding = '0px';
+    }
+    return `calc(${bottomContent}px + ${bottomPadding})`;
   }
 
   /**

--- a/src/kullna_editor.ts
+++ b/src/kullna_editor.ts
@@ -104,8 +104,13 @@ export interface KullnaEditor {
   get dir(): string;
   set dir(dir: string);
 
-  /** Gets the total height of the editor's content. */
-  get naturalHeight(): number;
+  /**
+   * Gets the total height of the editor's content as a CSS value such as `123px` or `min(x, y)`.
+   *
+   * @remarks
+   *   Intended to be queried as part of an `onUpdate` implementation.
+   */
+  get naturalHeight(): string;
 
   /**
    * Ensures a specific line number is within view.

--- a/src/kullna_editor.ts
+++ b/src/kullna_editor.ts
@@ -104,6 +104,9 @@ export interface KullnaEditor {
   get dir(): string;
   set dir(dir: string);
 
+  /** Gets the total height of the editor's content. */
+  get naturalHeight(): number;
+
   /**
    * Ensures a specific line number is within view.
    *


### PR DESCRIPTION
The new public property `naturalHeight` makes it possible to auto-size editors.

## Developer Certificate of Origin

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

- [x] I `<Steven E Wright>` agree to the **Developer Certificate of Origin**
- [x] I have reviewed the License Agreement at
      [LICENSE.md](https://github.com/kullna/editor/blob/main/LICENSE.md)
