### PR TITLE
fix: error with natural height when no lines exist

### DIFF
--- a/src/internals/text_editor/text_editor_view.ts
+++ b/src/internals/text_editor/text_editor_view.ts
@@ -266,6 +266,11 @@ export class TextEditorView {
 
   /** @inheritDoc */
   get naturalHeight(): string {
+    if (this.lineMetrics.length === 0) {
+      return `calc(${getComputedStyle(this.contentEditableSurface).paddingTop} + ${
+        getComputedStyle(this.contentEditableSurface).paddingBottom
+      })`;
+    }
     const lastLine = this.lineMetrics[this.lineMetrics.length - 1];
     const bottomContent = lastLine.top + lastLine.height;
     let bottomPadding = getComputedStyle(this.contentEditableSurface).paddingBottom;


### PR DESCRIPTION
Fixes a potential error that can occur when there are no text lines or the text metrics haven't been measured when the total height is requested.

## Developer Certificate of Origin

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

- [x] I `<Steven E Wright>` agree to the **Developer Certificate of Origin**
- [x] I have reviewed the License Agreement at
      [LICENSE.md](https://github.com/kullna/editor/blob/main/LICENSE.md)
